### PR TITLE
Add smiley support - because we all need smiles

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -43,10 +43,12 @@ IRCMessage.prototype.toString = function() {
     if (this.params.length !== 0) {
         for (i = 0; i < this.params.length; i++) {
             param = this.params[i];
-            if (param.indexOf(" ") === -1) {
-                string += "" + param + " ";
-            } else {
+
+            if (param.indexOf(" ") !== -1 ||
+                (i === (this.params.length - 1) && param[0] === ':')) {
                 string += ":" + param + " ";
+            } else {
+                string += param + " ";
             }
         }
     }

--- a/test/tostring.js
+++ b/test/tostring.js
@@ -45,6 +45,13 @@ vows.describe("Converting parsed messages to strings").addBatch({
             "should return '@test=super;single :test!me@test.ing FOO bar baz quux :This is a test'": function(topic) {
                 return topic.should.equal("@test=super;single :test!me@test.ing FOO bar baz quux :This is a test");
             }
+        },
+        "smiley face": {
+            topic: (ircmessage.parseMessage("PRIVMSG #smiley-test ::)")).toString(),
+
+            "should return 'PRIVMSG #smiley-test ::)": function(topic) {
+                return topic.should.equal("PRIVMSG #smiley-test ::)");
+            }
         }
     }
 }).export(module);


### PR DESCRIPTION
While implementing an [IRC server for ircanywhere](https://github.com/ircanywhere/ircanywhere/pull/70) I noticed that smiley faces where being butchered. This happens because the code on `toString()` was only prepending the `:` when there is a space in the param. One of the colons in a message such as `PRIVMSG #smiley-test ::)` ended up being dropped, causing clients to render just a sad `)`.
