### PR TITLE
A message must have a non-empty command

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -153,8 +153,10 @@ parseMessage = function(line) {
     if (nextspace === -1) {
         if (line.length > position) {
             message.command = line.slice(position);
+            return message;
         }
-        return message;
+        // Malformed IRC message.
+        return null;
     }
 
     // Else, the command is the current position up to the next space. After


### PR DESCRIPTION
I'm not sure how strict this parser is intended to be, but I have a light wrapper around it to make a transform stream and was writing tests when I encountered a few unexpected failures.

According to the pseudo BNF in RFC1459, the command part of a message is required and must be at least 1 character (1+ letters or exactly 3 digits, but that's a separate issue if it's wanted). This change makes the parser treat empty string and things like ": " as malformed in the same way that it already treats ":".
